### PR TITLE
Remove tinytoolstown references and align with Claude Code plugin docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,18 +1,19 @@
 {
-  "name": "tinytoolstown-marketplace",
+  "name": "agent-plugins",
   "owner": {
-    "name": "tinytoolstown",
-    "url": "https://github.com/tinytoolstown"
+    "name": "filipmares"
   },
-  "description": "A marketplace of tiny plugins intended to boost productivity for developers and anyone working with AI agents",
-  "homepage": "https://github.com/tinytoolstown/marketplace",
+  "description": "A marketplace of plugins intended to boost productivity for developers and anyone working with AI agents",
+  "homepage": "https://github.com/filipmares/agent-plugins",
   "plugins": [
     {
       "name": "cli-skill-generator",
       "source": "./plugins/cli-skill-generator",
       "description": "Generate Claude Code skills for any CLI tool",
       "category": "development-tools",
-      "author": "tinytoolstown"
+      "author": {
+        "name": "filipmares"
+      }
     }
   ]
 }

--- a/.templates/plugin-template/README.md
+++ b/.templates/plugin-template/README.md
@@ -25,8 +25,8 @@ plugin-template/
 Add the marketplace containing this plugin:
 
 ```bash
-/plugin marketplace add https://github.com/tinytoolstown/marketplace
-/plugin install plugin-template@tinytoolstown-marketplace
+/plugin marketplace add filipmares/agent-plugins
+/plugin install plugin-template@agent-plugins
 ```
 
 ## Usage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Test your plugin with Claude Code:
 
 ```bash
 /plugin marketplace add /path/to/marketplace
-/plugin install my-plugin@tinytoolstown-marketplace
+/plugin install my-plugin@agent-plugins
 ```
 
 ### 6. Submit Pull Request

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 tinytoolstown
+Copyright (c) 2026 filipmares
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Tiny Tools Plugin Marketplace
+# Plugin Marketplace
 
-A marketplace of tiny plugins intended to boost productivity for developers and anyone working with AI agents, following the official [Anthropic plugin marketplace guidelines](https://code.claude.com/docs/en/plugin-marketplaces).
+A marketplace of plugins intended to boost productivity for anyone working with AI agents, following the official [Anthropic plugin marketplace guidelines](https://code.claude.com/docs/en/plugin-marketplaces).
 
 ## Quick Start
 
@@ -9,7 +9,7 @@ A marketplace of tiny plugins intended to boost productivity for developers and 
 Add this marketplace to your agent:
 
 ```bash
-/plugin marketplace add https://github.com/tinytoolstown/marketplace
+/plugin marketplace add filipmares/agent-plugins
 ```
 
 ### Installing Plugins
@@ -19,7 +19,7 @@ Browse and install plugins from this marketplace:
 ```bash
 /plugin                                    # Open plugin browser UI
 /plugin list                               # List available plugins
-/plugin install <plugin-name>@tinytoolstown-marketplace
+/plugin install <plugin-name>@agent-plugins
 ```
 
 ## Managing Marketplaces

--- a/plugins/cli-skill-generator/.claude-plugin/plugin.json
+++ b/plugins/cli-skill-generator/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "cli-skill-generator",
   "version": "1.0.0",
   "description": "Generate Claude Code skills for any CLI tool",
-  "author": "tinytoolstown",
+  "author": "filipmares",
   "categories": ["development-tools"],
   "capabilities": {
     "skills": ["generate"]

--- a/plugins/cli-skill-generator/README.md
+++ b/plugins/cli-skill-generator/README.md
@@ -9,7 +9,7 @@ producing a complete plugin in any directory you choose.
 ## Installation
 
 ```
-/plugin install cli-skill-generator@tinytoolstown-marketplace
+/plugin install cli-skill-generator@agent-plugins
 ```
 
 ## Usage


### PR DESCRIPTION
- Replaced all tinytoolstown / Tiny Tools references across 7 files with filipmares for author, copyright, and ownership fields
- Updated all URLs and homepage links to point to https://github.com/filipmares/agent-plugins
- Aligned marketplace instructions with the official Claude Code plugin marketplace documentation (https://code.claude.com/docs/en/plugin-marketplaces):
  - Marketplace add commands now use the GitHub shorthand format (filipmares/agent-plugins) instead of full URLs
  - Changed plugins[].author from a plain string to the documented object format ({ "name": "filipmares" })
  - Removed owner.url field which is not part of the official schema
  - Renamed marketplace from the generic "marketplace" to "agent-plugins" to avoid collisions with other marketplaces