### PR TITLE
Fix plugin manifest to match official Claude Code schema

### DIFF
--- a/.templates/plugin-template/.claude-plugin/plugin.json
+++ b/.templates/plugin-template/.claude-plugin/plugin.json
@@ -2,12 +2,7 @@
   "name": "plugin-template",
   "version": "1.0.0",
   "description": "Template for creating Claude Code plugins",
-  "author": "Your Name",
+  "author": { "name": "Your Name" },
   "homepage": "https://github.com/username/plugin-template",
-  "license": "MIT",
-  "categories": ["development-tools"],
-  "capabilities": {
-    "skills": ["example-skill"]
-  },
-  "minClaudeCodeVersion": "1.0.0"
+  "license": "MIT"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,12 +25,8 @@ scripts/          # Validation and listing scripts (Bun + TS)
 ## Plugin Structure
 
 Each plugin lives in `plugins/<name>/` and requires:
-- `.claude-plugin/plugin.json` — manifest with name, version, description, author, categories, capabilities
+- `.claude-plugin/plugin.json` — manifest with name, version, description, author (object), and component paths
 - `README.md` — documentation
-
-## Valid Categories
-
-`development-tools`, `productivity`, `web-tools`, `data-tools`, `testing`, `security`, `documentation`, `deployment`
 
 ## Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,17 +48,11 @@ Every plugin must have a `.claude-plugin/plugin.json` file:
   "name": "your-plugin",
   "version": "1.0.0",
   "description": "Brief description of what your plugin does",
-  "author": "Your Name",
+  "author": { "name": "Your Name" },
   "homepage": "https://github.com/username/your-plugin",
   "license": "MIT",
-  "categories": ["development-tools"],
-  "capabilities": {
-    "skills": ["skill-name"],
-    "commands": ["command-name"],
-    "mcpServers": ["server-name"]
-  },
-  "dependencies": {},
-  "minClaudeCodeVersion": "1.0.0"
+  "skills": "./skills/",
+  "commands": "./commands/"
 }
 ```
 
@@ -67,29 +61,19 @@ Every plugin must have a `.claude-plugin/plugin.json` file:
 - `name`: Unique plugin identifier (lowercase, hyphens only)
 - `version`: Semantic version (e.g., "1.0.0")
 - `description`: Clear, concise description
-- `author`: Your name or organization
-- `categories`: Array of applicable categories
-- `capabilities`: Object listing what the plugin provides
+- `author`: Author object with `name` (required), `email` (optional), `url` (optional)
 
 ### Optional Fields
 
 - `homepage`: Link to plugin repository or website
+- `repository`: Repository URL
 - `license`: License identifier (default: MIT)
-- `dependencies`: External dependencies
-- `minClaudeCodeVersion`: Minimum Claude Code version required
-
-## Plugin Categories
-
-Choose one or more categories for your plugin:
-
-- **development-tools**: Code analysis, formatting, linting, build tools
-- **productivity**: Task automation, note-taking, workflow optimization
-- **web-tools**: Web scraping, HTTP clients, browser automation
-- **data-tools**: Data processing, transformation, analysis
-- **testing**: Test frameworks, test generation, quality assurance
-- **security**: Security scanning, vulnerability detection, compliance
-- **documentation**: Doc generation, API documentation, knowledge management
-- **deployment**: CI/CD, deployment automation, infrastructure
+- `keywords`: Array of keyword strings
+- `skills`: Path to skills directory
+- `commands`: Path to commands directory
+- `agents`: Path to agents directory
+- `hooks`: Path to hooks directory
+- `mcpServers`: Path to MCP servers directory
 
 ## Submission Process
 
@@ -129,8 +113,7 @@ Add your plugin to `.claude-plugin/marketplace.json`:
       "name": "my-plugin",
       "source": "./plugins/my-plugin",
       "description": "Brief description",
-      "category": "development-tools",
-      "author": "Your Name"
+      "author": { "name": "Your Name" }
     }
   ]
 }

--- a/plugins/cli-skill-generator/.claude-plugin/plugin.json
+++ b/plugins/cli-skill-generator/.claude-plugin/plugin.json
@@ -2,9 +2,6 @@
   "name": "cli-skill-generator",
   "version": "1.0.0",
   "description": "Generate Claude Code skills for any CLI tool",
-  "author": "filipmares",
-  "categories": ["development-tools"],
-  "capabilities": {
-    "skills": ["generate"]
-  }
+  "author": { "name": "filipmares" },
+  "skills": "./skills/"
 }


### PR DESCRIPTION
  - Fixed author field from string to object { "name": "..." } in all plugin.json files
   to match the official Claude Code plugin manifest schema
  - Removed unsupported categories, capabilities, minClaudeCodeVersion, and
  dependencies fields from manifests, template, and docs
  - Updated validation script and list script to validate against the correct schema
  (author object, component paths instead of capabilities)
  - Updated CONTRIBUTING.md and CLAUDE.md to document the correct official fields

  Context

  Installing the cli-skill-generator plugin was failing with:
  author: Invalid input: expected object, received string
  Unrecognized keys: "categories", "capabilities"

  The repo used a custom schema that didn't match the
  https://code.claude.com/docs/en/plugin-marketplaces. This PR aligns all manifests,
  scripts, and documentation with the official schema.