### PR TITLE
Improve CLI skill generator for large tools (v2.0.0)

### DIFF
--- a/plugins/cli-skill-generator/.claude-plugin/plugin.json
+++ b/plugins/cli-skill-generator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-skill-generator",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Generate Claude Code skills for any CLI tool",
   "author": { "name": "filipmares" },
   "skills": "./skills/"

--- a/plugins/cli-skill-generator/README.md
+++ b/plugins/cli-skill-generator/README.md
@@ -4,7 +4,8 @@
 
 A skill that generates CLI tool documentation plugins for use with Claude Code.
 Guides Claude through discovering CLI commands, grouping them into skills, and
-producing a complete plugin in any directory you choose.
+producing a complete plugin in any directory you choose. Handles tools of any
+size — from small CLIs to massive tools like `az` with 80+ command groups.
 
 ## Installation
 
@@ -22,9 +23,15 @@ Ask Claude to create a plugin for any CLI tool:
 
 The skill walks through a multi-step workflow:
 
-1. Verify the CLI tool is installed
-2. Choose an output directory for the generated plugin
-3. Discover commands via `--help`
-4. Group commands into 5-7 skill domains
-5. Generate all plugin files (plugin.json, SKILL.md files, README)
-6. Verify generated plugin structure
+1. Verify the CLI tool is installed and capture its version
+2. Discover commands via `--help`, produce a complete command manifest (with tier-based triage for large tools)
+3. Autonomously group all commands into skill domains (5-15 skills, scaling with tool size)
+4. Generate all plugin files:
+   - `plugin.json` manifest
+   - SKILL.md files (with two-tier documentation for large tools)
+   - Shared `references/version-check.md` (if version known)
+   - Shared `references/global-patterns.md` (if tool has global flags)
+   - README
+5. Verify coverage (every manifest command accounted for) and validate structure
+6. Present summary
+7. Offer to register the plugin, commit, and run a smoke test

--- a/plugins/cli-skill-generator/skills/generate/references/plugin-structure.md
+++ b/plugins/cli-skill-generator/skills/generate/references/plugin-structure.md
@@ -13,10 +13,13 @@ Use this reference when creating the directory structure and manifest for a CLI 
 ├── skills/                   # One subdirectory per skill (required)
 │   ├── <skill-1>/
 │   │   ├── SKILL.md          # Skill definition (required)
-│   │   └── references/       # Optional reference files
+│   │   └── references/       # Optional per-skill reference files
 │   ├── <skill-2>/
 │   │   └── SKILL.md
 │   └── .../
+├── references/               # Shared reference files (optional)
+│   ├── version-check.md      # Version check instructions (if cliVersion known)
+│   └── global-patterns.md    # Global flags & patterns (if tool has 3+ global flags)
 └── README.md                 # Plugin documentation (required)
 ```
 
@@ -29,10 +32,8 @@ Use this reference when creating the directory structure and manifest for a CLI 
   "name": "<tool-name>-cli",
   "version": "1.0.0",
   "description": "<Concise description of what the plugin provides>",
-  "author": "<your-name>",
-  "capabilities": {
-    "skills": ["<skill-1>", "<skill-2>", "..."]
-  },
+  "author": { "name": "<author-name>" },
+  "skills": "./skills/",
   "cliVersion": "<version>"
 }
 ```
@@ -44,21 +45,11 @@ Use this reference when creating the directory structure and manifest for a CLI 
 | `name` | string | Plugin name. Lowercase, hyphens only. Must match directory name. |
 | `version` | string | Semantic version (e.g., `1.0.0`). |
 | `description` | string | What the plugin does, 1 sentence. |
-| `author` | string | Author name or organization. |
-| `capabilities` | object | What the plugin provides. |
+| `author` | object | Author info. Object with a `name` field (e.g., `{ "name": "Your Name" }`). |
+| `skills` | string | Path to skills directory (e.g., `"./skills/"`). |
 | `cliVersion` | string | Semantic version of the CLI tool at generation time (e.g., `2.27.0`). Omit if unknown. |
 
 The `cliVersion` field records the version of the CLI tool that was installed when the plugin was generated. Generated skills use this to warn users when their installed version differs significantly, helping prevent issues with outdated or mismatched documentation.
-
-### Capability Types
-
-- `skills` — Array of skill names. Each must have a matching `skills/<name>/SKILL.md`.
-- `commands` — Array of command names. Each must have `commands/<name>/COMMAND.md`.
-- `agents` — Array of agent names.
-- `hooks` — Array of hook names.
-- `mcpServers` — Array of MCP server names.
-
-For CLI tool documentation plugins, use `skills` only.
 
 ---
 

--- a/plugins/cli-skill-generator/skills/generate/references/skill-template.md
+++ b/plugins/cli-skill-generator/skills/generate/references/skill-template.md
@@ -18,7 +18,7 @@ description: "Use when working with <tool> <domain>. Covers <key commands>."
 ### Frontmatter Rules
 
 - **name**: Lowercase, hyphens only. Must match the directory name (e.g., `skills/container-management/SKILL.md` has `name: container-management`).
-- **description**: Must start with `"Use when working with..."`. Keep under 150 characters. Should help Claude decide when to load this skill.
+- **description**: Must start with `"Use when working with..."`. Keep under 150 characters. Should help Claude decide when to load this skill. Be specific enough to route queries precisely — especially important for plugins with 10+ skills.
 
 ### Good vs. Bad Descriptions
 
@@ -44,7 +44,7 @@ Brief one-line summary of what this skill covers.
 
 ## Version Check
 
-<version check preamble — see Version Check Preamble section below>
+See [version-check.md](../references/version-check.md) for version verification.
 
 ## Commands
 
@@ -69,13 +69,15 @@ Brief one-line summary of what this skill covers.
 ...repeat for each command in this group...
 ```
 
+If `cliVersion` is **not** present in `plugin.json`, omit the `## Version Check` section entirely.
+
 ---
 
-## Version Check Preamble
+## Version Check Shared Reference
 
-When `cliVersion` is present in the plugin's `plugin.json`, every generated SKILL.md must include a `## Version Check` section immediately after the H1 heading and summary line, before `## Commands`. This section instructs Claude to verify the user's installed CLI version at invocation time.
+When `cliVersion` is present in the plugin's `plugin.json`, the generator creates a shared `references/version-check.md` file in the output plugin. Each generated SKILL.md links to it instead of repeating the version check logic.
 
-The `## Version Check` section should contain the following instructions (substituting the actual tool name):
+The shared `references/version-check.md` should contain these instructions (substituting the actual tool name):
 
 1. Run `<TOOL> --version` to get the installed version. If that fails, try `<TOOL> version`.
 2. Read `cliVersion` from this plugin's `plugin.json`.
@@ -86,7 +88,16 @@ The `## Version Check` section should contain the following instructions (substi
    - **Older major version** — warn: _"Your `<TOOL>` version (X.Y.Z) is a major version behind what this plugin was documented against (A.B.C). Many documented features may not exist in your version."_ Ask the user whether to proceed or stop (consider upgrading the CLI tool).
    - **Version not parseable or unavailable** — note: _"Could not determine `<TOOL>` version. Proceeding with documented commands — some may not match your installed version."_ Then proceed.
 
-If `cliVersion` is **not** present in `plugin.json`, omit the `## Version Check` section entirely.
+---
+
+## Two-Tier Command Documentation
+
+For plugins covering large CLI tools, use two tiers of documentation within each skill:
+
+- **Core commands** (Tier 1/2): Full documentation — description, flag table (3-5 flags), example (~15 lines per command)
+- **Minor commands** (Tier 3): Compact format — command name, one-line description, one example, no flag table (~5 lines per command)
+
+This gives full command coverage while keeping each skill under 300 lines.
 
 ---
 
@@ -97,7 +108,8 @@ If `cliVersion` is **not** present in `plugin.json`, omit the `## Version Check`
 3. **Key flags only.** Include 3-5 of the most useful flags per command. Skip rarely-used options.
 4. **Under 500 lines.** If a skill would exceed this, move detailed flag tables or advanced usage to `references/` files.
 5. **No tutorials.** Skills are reference material, not guides. Assume the user knows the tool basics.
-6. **Concrete values in examples.** Use realistic values, not placeholders like `<name>`. E.g., `docker run -d nginx` not `docker run -d <image>`.
+6. **Concrete values in examples.** Use descriptive defaults for user-chosen names (e.g., `my-rg`, `my-app`, `my-container`). Use zero-pattern placeholders for opaque/system-generated identifiers (e.g., `00000000-0000-0000-0000-000000000000` for UUIDs, `192.168.1.1` for IPs). Never use bare `<placeholder>` syntax.
+7. **Do not duplicate global flags** documented in `references/global-patterns.md`. If the plugin has a shared global patterns reference, omit those flags from individual command flag tables and link to the shared file instead.
 
 ---
 
@@ -114,7 +126,8 @@ Reference files use plain markdown (no frontmatter needed).
 
 ## Size Budget
 
-- **Per skill:** Aim for 100-300 lines. Max 500 lines.
+- **Per skill (5-7 skills):** Aim for 200-300 lines. Max 500 lines.
+- **Per skill (10+ skills):** Aim for 100-200 lines. Max 500 lines.
 - **Description:** 80-150 characters.
-- **Commands per skill:** 3-10. If you have more, consider splitting the skill.
-- **Flags per command:** 3-5 key flags in the main table.
+- **Commands per skill:** 3-15. If you have more, consider splitting the skill.
+- **Flags per command:** 3-5 key flags in the main table (3 for plugins with 10+ skills).

--- a/plugins/cli-skill-generator/skills/generate/references/validation-checklist.md
+++ b/plugins/cli-skill-generator/skills/generate/references/validation-checklist.md
@@ -14,14 +14,12 @@ Use this reference to verify a generated plugin is structurally correct and foll
 - `name` — must be present
 - `version` — must be present
 - `description` — must be present
-- `author` — must be present
-- `capabilities` — must be present
+- `author` — must be present, must be an object with a `name` field (e.g., `{ "name": "Author Name" }`)
+- `skills` — must be present, must be a string path (e.g., `"./skills/"`)
 - `cliVersion` — must be present if CLI version was captured during generation
 
-### Capability Matching
-For each skill listed in `capabilities.skills`, verify that `skills/<name>/SKILL.md` exists. Each SKILL.md must have valid YAML frontmatter with `name` and `description` fields.
-
-Same for `capabilities.commands` — each must have `commands/<name>/COMMAND.md`.
+### Skill Matching
+For each skill directory under `skills/`, verify that `SKILL.md` exists. Each SKILL.md must have valid YAML frontmatter with `name` and `description` fields.
 
 ### README Checks
 - Should start with a main heading (`# Title`)
@@ -35,11 +33,35 @@ Keep generated plugins within these budgets:
 
 | Metric | Target | Maximum |
 |--------|--------|---------|
-| Skills per plugin | 5-7 | 10 |
+| Skills per plugin (small tools) | 5-7 | 15 |
+| Skills per plugin (large tools) | 10-15 | 15 |
 | Commands per skill | 3-10 | 15 |
 | Description length | ~100 chars | 150 chars |
-| SKILL.md lines | 100-300 | 500 |
+| SKILL.md lines (5-7 skills) | 200-300 | 500 |
+| SKILL.md lines (10+ skills) | 100-200 | 500 |
 | Total plugin size | ~16 KB | 32 KB |
+
+---
+
+## Shared Reference Files
+
+### Version Check (`references/version-check.md`)
+- Must exist if `cliVersion` is present in `plugin.json`
+- Each SKILL.md must include a `## Version Check` section linking to this file
+- Should NOT be created if `cliVersion` is unknown or absent
+
+### Global Patterns (`references/global-patterns.md`)
+- Should exist if the CLI tool has 3+ global flags
+- Should cover global flags, output formatting, and query syntax
+- Individual skill flag tables must NOT duplicate flags documented here
+
+---
+
+## Command Coverage
+
+- Every command discovered in the Step 2 manifest must appear in at least one generated SKILL.md
+- No commands may be silently dropped during grouping or generation
+- For large tools, Tier 3 commands may use compact format (name + one-line description + one example) but must still be present
 
 ---
 
@@ -49,11 +71,15 @@ Before considering the plugin complete, verify:
 
 - [ ] `plugin.json` has all required fields
 - [ ] `plugin.json` parses as valid JSON
-- [ ] Every skill in `capabilities.skills` has a corresponding `skills/<name>/SKILL.md`
+- [ ] `plugin.json` uses correct schema (`author` as object, `skills` as string path)
+- [ ] Every skill directory has a corresponding `skills/<name>/SKILL.md`
 - [ ] Every SKILL.md has valid frontmatter with `name` and `description`
 - [ ] Descriptions start with "Use when working with..."
 - [ ] README.md has Overview, Installation, and Usage sections
-- [ ] Total skill count is 5-7
+- [ ] Total skill count is appropriate (5-7 for small tools, up to 15 for large tools)
 - [ ] No SKILL.md exceeds 500 lines
 - [ ] `plugin.json` includes `cliVersion` if CLI version was captured during generation
-- [ ] Every SKILL.md includes a `## Version Check` section (if `cliVersion` is present in `plugin.json`)
+- [ ] `references/version-check.md` exists and each SKILL.md links to it (if `cliVersion` is present)
+- [ ] `references/global-patterns.md` exists if the tool has 3+ global flags
+- [ ] Global flags are not duplicated in individual skill flag tables
+- [ ] 100% command coverage: every manifest entry appears in at least one SKILL.md


### PR DESCRIPTION
## Improve CLI Skill Generator for Large Tools (v2.0.0)

  After using the generator to build an Azure CLI plugin (80+ command groups, 7 skills, 69 commands), several pain points surfaced.
  This PR makes the generator robust for CLI tools of any size.

  ### Problem

  The generator silently dropped most discovered commands for large tools, repeated boilerplate in every skill file, used the wrong
  `plugin.json` schema, and gave no guidance for massive command surfaces.

  ### Changes

  **Complete command coverage (critical)**
  - Step 2 now produces a command manifest — a structured ground truth of ALL discovered commands
  - Step 3 autonomously groups commands (no longer blocks on user confirmation) and scales from 5-15 skills based on tool size
  - New Step 4f: coverage verification cross-references manifest against generated SKILL.md files — any missing command is a
  generation failure
  - Tier-based triage for large tools (15+ groups): Core/Common groups get full `--help` exploration, Niche groups use top-level
  descriptions only — but all tiers are included

  **Fix `plugin.json` schema**
  - `author` is now an object (`{ "name": "..." }`) not a string
  - `skills` is now a top-level string path (`"./skills/"`) not `capabilities.skills` array
  - Aligns with the actual marketplace schema per CONTRIBUTING.md

  **Shared references to reduce duplication**
  - Version check logic extracted to `references/version-check.md` (was ~12 lines repeated per skill)
  - New `references/global-patterns.md` for cross-cutting flags (e.g., `--output`, `--query`)
  - Each SKILL.md links to shared files instead of duplicating content

  **Additional improvements**
  - Two-tier command documentation: full docs for core commands, compact format for niche commands
  - Parallelism guidance for help commands and SKILL.md generation
  - Size budget surfaced in SKILL.md (was only in validation-checklist)
  - Validation reads files from disk instead of relying on memory
  - New Step 7: finalization (register plugin, offer commit, suggest smoke test)
  - Skill cap raised from 10 to 15
  - Clarified example value rules (descriptive names vs zero-pattern placeholders for opaque IDs)

  ### Files changed (6)

  | File | Summary |
  |------|---------|
  | `skills/generate/SKILL.md` | Main workflow: manifest, triage, autonomous grouping, shared refs, coverage verification,
  finalization |
  | `skills/generate/references/plugin-structure.md` | Fixed schema, added shared references to directory layout |
  | `skills/generate/references/skill-template.md` | Version check extraction, global flag dedup rule, two-tier docs, example values
  |
  | `skills/generate/references/validation-checklist.md` | Raised skill cap, fixed schema refs, added coverage/shared-ref checks |
  | `.claude-plugin/plugin.json` | Version bump to 2.0.0 |
  | `README.md` | Updated workflow description |

  ### Validation

  - `bun run scripts/validate-plugin.ts plugins/cli-skill-generator` passes with no errors or warnings
  - Cross-file consistency verified across all 5 content files (schema references, size budgets, step numbering)