### PR TITLE
Add consensus-planner plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,6 +23,15 @@
       "author": {
         "name": "filipmares"
       }
+    },
+    {
+      "name": "consensus-planner",
+      "source": "./plugins/consensus-planner",
+      "description": "Multi-model iterative consensus planning — spawns parallel agents to create, critique, and converge on implementation plans",
+      "category": "development-tools",
+      "author": {
+        "name": "filipmares"
+      }
     }
   ]
 }

--- a/plugins/consensus-planner/.claude-plugin/plugin.json
+++ b/plugins/consensus-planner/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "consensus-planner",
+  "version": "1.1.0",
+  "description": "Multi-model iterative consensus planning — spawns parallel agents to create, critique, and converge on implementation plans",
+  "author": { "name": "filipmares" },
+  "homepage": "https://github.com/filipmares/agent-plugins",
+  "license": "MIT",
+  "skills": "./skills/"
+}

--- a/plugins/consensus-planner/CHANGELOG.md
+++ b/plugins/consensus-planner/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 1.1.0
+
+### Hardening: Prevent agents from skipping the skill protocol
+
+**Problem:** When the plan skill was invoked, agents would read the reference templates but skip SKILL.md entirely — improvising model selection, skipping feedback rounds, and producing free-form output instead of the structured consensus report.
+
+**Changes:**
+
+- **Added Rules section** at the top of SKILL.md with explicit DO NOT guardrails (e.g., do not select models without asking the user, do not skip cost estimate)
+- **Added Step 0: Verify Skill Loaded** — agent must display a confirmation message and progress checklist before proceeding, proving SKILL.md is in context
+- **Added progress checklist** — visible `☐`/`▶`/`☑` tracker updated at each step to keep agent and user aligned
+- **Reordered Step 1** — model discovery is now substep 1a (before task prompt and codebase gathering), anchoring the workflow in concrete runtime data immediately
+- **Added header comments to reference templates** — `planning-prompt.md` and `feedback-prompt.md` now include HTML comments pointing back to SKILL.md, preventing the failure mode where agents read templates but not the orchestration instructions
+
+## 1.0.0
+
+- Initial release with 6-step consensus planning workflow
+- Multi-model parallel planning with iterative feedback rounds
+- Convergence detection and consensus synthesis with confidence markers
+- Support for both Copilot CLI (cross-vendor) and Claude Code (cross-tier) runtimes

--- a/plugins/consensus-planner/README.md
+++ b/plugins/consensus-planner/README.md
@@ -1,0 +1,51 @@
+# Consensus Planner
+
+## Overview
+
+A skill that creates implementation plans using multiple AI models in parallel, runs iterative feedback rounds where each model critiques and refines all plans, and synthesizes a consensus plan. Works with both GitHub Copilot CLI (full cross-vendor model pool) and Claude Code (Anthropic models only). Models are discovered dynamically at runtime — no hardcoded lists.
+
+## Installation
+
+```
+/plugin install consensus-planner@agent-plugins
+```
+
+## Usage
+
+Ask the agent to create a consensus plan:
+
+- "Create a consensus plan for adding authentication to the API"
+- "Multi-model plan for refactoring the database layer"
+- Or invoke directly with the skill tool
+
+The skill walks through a structured workflow:
+
+1. **Setup** — Gather the task description and relevant codebase context automatically
+2. **Configure** — Select 1–5 models from the dynamically discovered pool, choose feedback rounds (2/3/5)
+3. **Plan** — Launch parallel agents that independently produce structured implementation plans
+4. **Iterate** — Each agent reviews all plans, critiques them, and revises their own; repeat until convergence or max rounds
+5. **Synthesize** — Merge final plans into a consensus report with confidence markers
+6. **Report** — Present the merged plan with consensus breakdown, open questions, and model attribution
+
+### Single-Model Mode
+
+If only 1 model is selected, the skill produces a single plan without feedback rounds. Useful for quick planning or when only one model is available.
+
+### Iterative Convergence
+
+With 2+ models, the skill runs feedback rounds where each agent sees all other plans and revises their own. Plans typically converge within 2–3 rounds. The skill detects convergence automatically and exits early when all models agree.
+
+### Cost Awareness
+
+The skill calculates and displays estimated premium request usage before starting:
+
+> **Estimated cost:** 3 models × (3 rounds + 1 initial) = **12 premium requests**
+
+### Runtime Compatibility
+
+| Runtime | Model Pool | Detection |
+|---------|-----------|-----------|
+| **Copilot CLI** | Claude + GPT + Gemini (cross-vendor) | Non-Anthropic models present |
+| **Claude Code** | Claude only (cross-tier) | Only Anthropic models present |
+
+The same skill works in both environments. The agent reads its own `task` tool documentation to discover available models at runtime.

--- a/plugins/consensus-planner/skills/plan/SKILL.md
+++ b/plugins/consensus-planner/skills/plan/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: plan
+description: "Use when creating an implementation plan using multiple AI models that iterate toward consensus. Spawns parallel agents with user-selected models to independently plan, exchange feedback, and converge. Trigger on requests like 'consensus plan for <task>' or 'multi-model plan for <feature>'."
+---
+
+# Multi-Model Consensus Planner
+
+**CRITICAL: Read this entire SKILL.md before taking any action. Follow each numbered step exactly. Do NOT improvise the workflow.**
+
+Create an implementation plan by spawning multiple AI agents (each using a different model), running iterative feedback rounds, and synthesizing a consensus plan. Follow these steps in order. Do not skip steps.
+
+## Rules
+
+You **MUST** follow the step-by-step protocol below. These rules are non-negotiable:
+
+- **DO NOT** select models without asking the user via `ask_user`
+- **DO NOT** skip the cost estimate confirmation in Step 2
+- **DO NOT** skip feedback rounds (Step 4) unless only 1 model is selected
+- **DO NOT** use your own plan format — use the 7-section template from `references/planning-prompt.md`
+- **DO NOT** synthesize without confidence markers (`[consensus]`/`[majority]`/`[divergent]`)
+- **DO NOT** launch planning agents (Step 3) without completing Step 2 (Configure) first
+- If you find yourself launching agents before the user has selected models and confirmed cost, **STOP** and go back to Step 2
+
+---
+
+## Step 0: Verify Skill Loaded
+
+Before proceeding, confirm you have read this SKILL.md in full. Display to the user:
+
+> 🔧 **Consensus Planner skill loaded.** Starting setup...
+
+Then display the progress checklist:
+
+> ▶ Step 0: Skill Loaded
+> ☐ Step 1: Setup & Context
+> ☐ Step 2: Configure (models, rounds, cost)
+> ☐ Step 3: Initial Planning
+> ☐ Step 4: Feedback Rounds
+> ☐ Step 5: Consensus Synthesis
+> ☐ Step 6: Final Report
+
+**At the start of each subsequent step**, redisplay this checklist with the current step marked `▶`, completed steps marked `☑`, and pending steps marked `☐`. This keeps you and the user aligned on progress.
+
+---
+
+## Step 1: Setup & Context Gathering
+
+**1a: Discover available models (do this FIRST):**
+
+Read your own `task` tool documentation. Look at the `model` parameter description — it lists all available model names. Extract every model name from that list. Store as `AVAILABLE_MODELS`.
+
+**1b: Identify runtime:**
+- If `AVAILABLE_MODELS` contains any non-Anthropic models (names starting with `gpt-` or `gemini-`) → runtime is **Copilot CLI**
+- If `AVAILABLE_MODELS` contains only Anthropic models (names starting with `claude-`) → runtime is **Claude Code**
+
+Store as `RUNTIME`. Inform the user:
+> Detected runtime: **<RUNTIME>**. Found **<count>** available models.
+
+**1c: Get the task prompt:**
+
+If the user already provided a task description when invoking this skill, use it. Otherwise, ask via `ask_user`:
+
+> What task or feature do you want to plan? Describe it in as much detail as possible.
+
+Store as `TASK_PROMPT`.
+
+**1d: Gather codebase context:**
+
+Use `glob` to discover the project structure:
+
+```
+**/*.{ts,js,tsx,jsx,py,rs,go,java,cs,md,json,yaml,yml,toml}
+```
+
+Identify the most relevant files using these heuristics (in priority order):
+1. README, CONTRIBUTING, or architecture docs at the repo root
+2. Package manifests (package.json, Cargo.toml, go.mod, pyproject.toml, *.csproj, etc.)
+3. Entry points and main source files
+4. Files whose names or paths relate to keywords in `TASK_PROMPT`
+5. Configuration files (.env.example, tsconfig.json, etc.)
+
+Use `view` to read up to 10 of the most relevant files. Concatenate their contents with file path headers as `CODEBASE_CONTEXT`:
+
+```
+### <relative-file-path>
+<file contents>
+```
+
+If the project has more than 200 files, tell the user which files you selected and ask if they want to add or replace any.
+
+---
+
+## Step 2: Configure
+
+**Model selection:**
+
+Ask the user to select models via `ask_user`. Present all `AVAILABLE_MODELS` as choices.
+
+Rules:
+- Minimum 1 model, maximum 5
+- Suggest 2 as a good default for cost/diversity balance
+- For **Copilot CLI**, recommend picking models from different vendors (e.g., one Claude + one GPT + one Gemini)
+- For **Claude Code**, recommend picking models from different tiers (e.g., Opus + Sonnet)
+- If user selects more than 5, explain the constraint and ask again
+
+Store as `SELECTED_MODELS`.
+
+**If only 1 model selected:** Inform the user that iterative feedback requires 2+ models. Ask:
+- "Continue with single-model planning (no feedback rounds)"
+- "Go back and select more models"
+
+If single-model: skip to Step 3, produce one plan, skip Steps 4-5, go directly to Step 6 with that plan.
+
+**Max feedback rounds:**
+
+Ask via `ask_user` with choices:
+- "2 rounds (fast)"
+- "3 rounds (Recommended)"
+- "5 rounds (thorough)"
+
+Store the number as `MAX_ROUNDS`.
+
+**Cost estimate:**
+
+Calculate and display:
+> **Estimated cost:** <SELECTED_MODELS count> models × (<MAX_ROUNDS> feedback rounds + 1 initial) = **<total> premium requests**
+>
+> Proceed?
+
+Use `ask_user` with choices:
+- "Yes, proceed"
+- "Adjust configuration"
+
+If "Adjust," loop back to model selection.
+
+---
+
+## Step 3: Parallel Initial Planning
+
+Read the planning prompt template from `references/planning-prompt.md` (relative to this SKILL.md file).
+
+Replace placeholders:
+- `{TASK_PROMPT}` → the user's task description
+- `{CODEBASE_CONTEXT}` → the gathered codebase context
+
+**Launch parallel planning agents:**
+
+For each model in `SELECTED_MODELS`, use the `task` tool with:
+- `agent_type`: `"general-purpose"`
+- `model`: the model name
+- `mode`: `"background"`
+- `prompt`: the complete planning prompt with placeholders filled
+
+Launch ALL agents simultaneously in a single response (parallel tool calls).
+
+**Wait for all agents to complete:**
+
+Use `read_agent` with `wait: true` for each agent. Collect all responses.
+
+If any agent fails, note the failure and continue with remaining results. If all agents fail, stop and report the error to the user.
+
+Store results as `PLANS` — a map of model name → plan text.
+
+**Present summaries:**
+
+For each plan, extract and display:
+- Model name
+- The "Problem Restatement" section (1-2 sentences)
+- The "Proposed Approach" section (first paragraph only)
+- Complexity estimate
+- Number of files to change
+
+```
+### Initial Plans Summary
+
+**<model1>:** <approach summary> | Complexity: <S/M/L> | Files: <N>
+**<model2>:** <approach summary> | Complexity: <S/M/L> | Files: <N>
+...
+```
+
+---
+
+## Step 4: Iterative Feedback Rounds
+
+**If only 1 model was selected:** Skip this step entirely.
+
+Read the feedback prompt template from `references/feedback-prompt.md` (relative to this SKILL.md file).
+
+For each round (1 through `MAX_ROUNDS`):
+
+**4a: Construct feedback prompts**
+
+For each model in `SELECTED_MODELS`, replace placeholders in the feedback template:
+- `{TASK_PROMPT}` → the user's task description
+- `{CODEBASE_CONTEXT}` → the gathered codebase context
+- `{OWN_PLAN}` → this model's plan from the previous round
+- `{ALL_PLANS}` → all models' plans from the previous round, each wrapped as:
+  ```
+  --- Plan by <model name> ---
+  <plan text>
+  --- End of plan by <model name> ---
+  ```
+
+**4b: Launch parallel feedback agents**
+
+For each model, use the `task` tool with:
+- `agent_type`: `"general-purpose"`
+- `model`: the same model that produced the plan
+- `mode`: `"background"`
+- `prompt`: the filled feedback prompt
+
+Launch ALL agents simultaneously.
+
+**4c: Collect results**
+
+Use `read_agent` with `wait: true` for each agent. Update `PLANS` with the new revised plans.
+
+If an agent fails in this round, carry forward its plan from the previous round. Note the failure.
+
+**4d: Convergence check**
+
+Compare this round's plans to the previous round. Check for convergence by examining:
+1. Do all plans agree on the same overall approach/architecture?
+2. Do the file change lists substantially overlap?
+3. Are the key design decisions aligned?
+4. Did the "Changes From Previous Round" sections show only minor refinements?
+
+**If converged** (all plans substantially agree on approach, files, and key decisions):
+> ✅ **Round <N>/<MAX_ROUNDS> complete — Converged.** All models agree on the approach. Proceeding to synthesis.
+
+Exit the loop. Proceed to Step 5.
+
+**If NOT converged and rounds remain:**
+> 🔄 **Round <N>/<MAX_ROUNDS> complete — Key disagreements remain:**
+> - <topic 1>: <model A> vs <model B>
+> - <topic 2>: ...
+>
+> Continuing to next round.
+
+Continue the loop.
+
+**If NOT converged and no rounds remain:**
+> ⚠️ **Round <MAX_ROUNDS>/<MAX_ROUNDS> complete — Max rounds reached.** Some disagreements remain. Proceeding to synthesis with divergent elements noted.
+
+Proceed to Step 5.
+
+---
+
+## Step 5: Consensus Synthesis
+
+**If only 1 model was used:** Skip this step. Use the single plan directly in Step 6.
+
+Analyze all final-round plans side by side. For every planning element (approach, each file change, each design decision, testing strategy), categorize it:
+
+### Consensus (highest confidence)
+Elements where ALL models agree. These form the backbone of the final plan. Use the clearest articulation among the models.
+
+### Majority (high confidence)
+Elements where 2+ models agree but not all. Use the majority position. Note the dissenting model's alternative in parentheses.
+
+### Divergent (open questions)
+Elements where models fundamentally disagree. Present both/all perspectives and let the user decide.
+
+**Merge into a single consensus plan** following the same 7-section structure from the planning prompt:
+1. Problem Restatement (consensus version)
+2. Proposed Approach (merged — flag any majority/divergent elements)
+3. File-by-File Change List (union of all agreed changes, with confidence markers)
+4. Key Design Decisions (consensus decisions + open questions for divergent ones)
+5. Risk Areas & Edge Cases (union from all models — more eyes = more risks found)
+6. Testing Approach (merged)
+7. Complexity Estimate (majority vote or range if disagreed)
+
+Mark each element with its confidence level:
+- `[consensus]` — all models agree
+- `[majority: N/M]` — N of M models agree
+- `[divergent]` — models disagree (see Open Questions)
+
+---
+
+## Step 6: Present Final Report
+
+Present the complete consensus plan to the user:
+
+```
+## Consensus Plan: <one-line task summary>
+
+### Configuration
+- **Models:** <model1>, <model2>[, ...]
+- **Rounds completed:** <N> (<converged at round M> | <reached max>)
+- **Runtime:** <Copilot CLI | Claude Code>
+
+### Plan
+
+<the merged consensus plan with all 7 sections, including [consensus]/[majority]/[divergent] markers>
+
+### Consensus Breakdown
+- **Full agreement:** <N> elements
+- **Majority agreement:** <N> elements
+- **Divergent (open questions):** <N> elements
+
+### Open Questions
+
+<if any divergent elements exist, list them>
+
+1. **<topic>**
+   - <model1> recommends: <approach>
+   - <model2> recommends: <approach>
+   - <context for user to decide>
+
+<if no divergent elements>
+None — all models converged on the same plan.
+
+### Model Attribution
+<for each model>
+- **<model>:** <1-2 sentence summary of this model's key contributions or unique insights>
+```
+
+**After presenting the report:** Do not take further action. The user can use this plan to guide implementation, ask follow-up questions, or invoke other tools.

--- a/plugins/consensus-planner/skills/plan/references/feedback-prompt.md
+++ b/plugins/consensus-planner/skills/plan/references/feedback-prompt.md
@@ -1,0 +1,61 @@
+<!-- This template is used by SKILL.md Step 4. Do not use directly.
+     Read SKILL.md for the full workflow. Placeholders: {TASK_PROMPT}, {CODEBASE_CONTEXT}, {OWN_PLAN}, {ALL_PLANS} -->
+
+# Feedback & Revision Prompt
+
+You are an expert software architect participating in a multi-model planning review.You previously produced a plan. Now you must review all plans (yours and others), critique them, and produce a revised plan that incorporates the best ideas.
+
+## Task
+
+{TASK_PROMPT}
+
+## Codebase Context
+
+{CODEBASE_CONTEXT}
+
+## Your Previous Plan
+
+{OWN_PLAN}
+
+## All Plans Under Review
+
+The following plans were produced independently by different AI models. Each is labeled with the model that produced it.
+
+{ALL_PLANS}
+
+## Instructions
+
+### Phase 1: Critique (do this analysis internally, do not output it)
+
+For each plan (including your own), evaluate:
+1. **Strengths** — What does this plan get right? What ideas are worth adopting?
+2. **Weaknesses** — What is missing, risky, or overcomplicated?
+3. **Unique contributions** — What does this plan propose that others don't?
+
+### Phase 2: Revised Plan (output this)
+
+Produce a **revised implementation plan** that:
+- Keeps the best elements from all plans (not just your own)
+- Addresses weaknesses you identified
+- Resolves conflicts between plans by choosing the stronger approach (with justification)
+- Maintains the same structure as the original plan (all 7 sections)
+
+### Phase 3: Change Log (append after the revised plan)
+
+After your revised plan, add a section:
+
+```
+## Changes From Previous Round
+- **Adopted from <model>:** <what you took and why>
+- **Dropped:** <what you removed from your previous plan and why>
+- **New:** <anything you added that wasn't in any plan>
+- **Unchanged:** <key decisions you kept and why>
+```
+
+## Rules
+
+- Do NOT blindly merge — if plans conflict, pick the better approach and explain why.
+- Do NOT inflate the plan. If your previous plan was already good, small refinements are fine.
+- If all plans substantially agree on a point, keep it and note the consensus.
+- Keep the revised plan under 500 lines. Focus on structure, not verbatim code.
+- Be specific about what changed and why. Vague statements like "improved the approach" are not acceptable.

--- a/plugins/consensus-planner/skills/plan/references/planning-prompt.md
+++ b/plugins/consensus-planner/skills/plan/references/planning-prompt.md
@@ -1,0 +1,68 @@
+<!-- This template is used by SKILL.md Step 3. Do not use directly.
+     Read SKILL.md for the full workflow. Placeholders: {TASK_PROMPT}, {CODEBASE_CONTEXT} -->
+
+# Planning Prompt
+
+You are an expert software architect.Given a task description and codebase context, produce a detailed implementation plan.
+
+## Task
+
+{TASK_PROMPT}
+
+## Codebase Context
+
+The following files are from the project you are planning changes for. Use them to understand the existing architecture, patterns, and conventions.
+
+{CODEBASE_CONTEXT}
+
+## Instructions
+
+Produce a structured implementation plan. Be specific — cite file paths, function names, and line numbers where applicable. Keep the plan concise (under 500 lines) and focused on structure rather than verbatim code.
+
+### Required Sections
+
+#### 1. Problem Restatement
+Restate the task in your own words to verify understanding. Call out any ambiguities or assumptions you are making.
+
+#### 2. Proposed Approach
+Describe the high-level architecture and strategy. Explain **why** this approach was chosen over alternatives.
+
+#### 3. File-by-File Change List
+For each file that needs to be created or modified:
+
+```
+**`<file path>`** [create | modify]
+- <what changes and why>
+- <key functions/classes affected>
+```
+
+Order files by dependency (foundations first, then consumers).
+
+#### 4. Key Design Decisions
+List the important design choices and their tradeoffs. For each:
+- **Decision:** what you chose
+- **Alternatives considered:** what else could work
+- **Rationale:** why this is the best option given the codebase
+
+#### 5. Risk Areas & Edge Cases
+Identify the trickiest parts of the implementation:
+- What could go wrong?
+- What edge cases need handling?
+- What assumptions might break?
+
+#### 6. Testing Approach
+How should this be tested?
+- Unit tests (what to test, key assertions)
+- Integration tests (if applicable)
+- Manual verification steps
+
+#### 7. Complexity Estimate
+Rate overall complexity: **Small** / **Medium** / **Large**
+Briefly justify the rating.
+
+## Rules
+
+- Be concrete — no hand-waving. Every recommendation should be actionable.
+- Respect existing patterns in the codebase. Do not propose unnecessary refactors.
+- If you need information not provided in the context, state what is missing and what you assumed.
+- Focus on the minimal set of changes needed. Less is more.


### PR DESCRIPTION
## Summary

- Adds the `consensus-planner` plugin — multi-model iterative consensus planning that spawns parallel agents to create, critique, and converge on implementation plans
- Registers `consensus-planner` in the marketplace manifest
- Includes skill, reference prompts, README, and changelog

## Test plan

- [ ] Run `bun run scripts/validate-plugin.ts plugins/consensus-planner` — passes
- [ ] Run `bun run scripts/list-plugins.ts` — shows consensus-planner in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)