### PR TITLE
Bump consensus-planner to 1.2.0

### DIFF
--- a/plugins/consensus-planner/.claude-plugin/plugin.json
+++ b/plugins/consensus-planner/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-planner",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Multi-model iterative consensus planning — spawns parallel agents to create, critique, and converge on implementation plans",
   "author": { "name": "filipmares" },
   "homepage": "https://github.com/filipmares/agent-plugins",

--- a/plugins/consensus-planner/CHANGELOG.md
+++ b/plugins/consensus-planner/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.2.0
+
+### Prompt quality, convergence, and reliability improvements
+
+**Changes:**
+
+- **Context exclusion patterns** — Step 1d now excludes `node_modules`, `dist`, `build`, `.next`, `vendor`, `__pycache__`, and other non-source directories/files from the glob, preventing wasted context slots
+- **Fixed-format output fields** — Planning prompt now requires `**Complexity: S | M | L**` and `**Files changed: <N>**` for reliable summary extraction and convergence checks
+- **Explicit Assumptions section** — Planning prompt requires a dedicated Assumptions subsection, surfacing implicit assumptions that cause plan divergence
+- **Multi-step model selection** — Step 2 uses an iterative `ask_user` loop to work within the single-select constraint, fixing a functional limitation
+- **Agent failure retry** — Steps 3 and 4 now retry failed agents once before falling back, improving resilience against transient API failures
+- **Output structure validation** — Step 3 validates that all 7 required sections are present in agent output, with a single retry for missing sections
+- **Disagreement ledger** — Feedback prompt now includes structured "Disagreements Resolved" and "Remaining Disagreements" sections, replacing vague convergence heuristics with agent-reported data
+- **Synthesis prompt template** — Created `references/synthesis-prompt.md` for Step 5, matching the template pattern of Steps 3 and 4. The most critical step now has a dedicated, structured template instead of inline prose
+
 ## 1.1.0
 
 ### Hardening: Prevent agents from skipping the skill protocol


### PR DESCRIPTION
## Summary

Bumps consensus-planner from 1.1.0 to 1.2.0 and adds a CHANGELOG entry documenting the 8 improvements shipped in PRs #26–#33.

## Changes

- **`plugin.json`** — Version `1.1.0` → `1.2.0`
- **`CHANGELOG.md`** — Added 1.2.0 entry covering all improvements:
  - Context exclusion patterns (#18)
  - Fixed-format output fields (#19)
  - Explicit Assumptions section (#20)
  - Multi-step model selection (#21)
  - Agent failure retry (#22)
  - Output structure validation (#23)
  - Disagreement ledger (#24)
  - Synthesis prompt template (#25)