### PR TITLE
fix: add version field to marketplace plugin entries

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,7 @@
     {
       "name": "cli-skill-generator",
       "source": "./plugins/cli-skill-generator",
+      "version": "2.0.0",
       "description": "Generate Claude Code skills for any CLI tool",
       "category": "development-tools",
       "author": {
@@ -18,6 +19,7 @@
     {
       "name": "plugin-analyzer",
       "source": "./plugins/plugin-analyzer",
+      "version": "1.0.0",
       "description": "Analyze plugins using multiple AI models in parallel, synthesize consensus findings, and create GitHub issues",
       "category": "development-tools",
       "author": {
@@ -27,6 +29,7 @@
     {
       "name": "consensus-planner",
       "source": "./plugins/consensus-planner",
+      "version": "1.2.0",
       "description": "Multi-model iterative consensus planning — spawns parallel agents to create, critique, and converge on implementation plans",
       "category": "development-tools",
       "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to the agent-plugins marketplace will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and plugin versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- Add `version` field to all plugin entries in `marketplace.json` so marketplace installs correctly record plugin versions ([#35](https://github.com/filipmares/agent-plugins/pull/35))
+
+## 2026-02-11
+
+### Added — consensus-planner v1.2.0
+- Dedicated synthesis prompt template for Step 5 ([#33](https://github.com/filipmares/agent-plugins/pull/33))
+- Disagreement ledger to feedback prompt for structured convergence ([#32](https://github.com/filipmares/agent-plugins/pull/32))
+- Output structure validation with single retry after plan collection ([#31](https://github.com/filipmares/agent-plugins/pull/31))
+- Single retry for failed agents in Steps 3 and 4 ([#30](https://github.com/filipmares/agent-plugins/pull/30))
+- Explicit Assumptions section to planning prompt ([#28](https://github.com/filipmares/agent-plugins/pull/28))
+- Fixed-format complexity and file count fields to planning prompt ([#27](https://github.com/filipmares/agent-plugins/pull/27))
+- Context exclusion patterns to Step 1d glob ([#26](https://github.com/filipmares/agent-plugins/pull/26))
+
+### Fixed — consensus-planner
+- Multi-select model selection UX with iterative `ask_user` loop ([#29](https://github.com/filipmares/agent-plugins/pull/29))
+
+### Added — consensus-planner v1.0.0
+- Multi-model iterative consensus planning plugin ([#17](https://github.com/filipmares/agent-plugins/pull/17))
+
+### Added — plugin-analyzer v1.0.0
+- Plugin analyzer with multi-model analysis capabilities ([#16](https://github.com/filipmares/agent-plugins/pull/16))
+
+## 2026-02-09
+
+### Changed — cli-skill-generator v2.0.0
+- Improved handling for large CLI tools ([#6](https://github.com/filipmares/agent-plugins/pull/6))
+
+## 2026-02-07
+
+### Added — cli-skill-generator v1.0.0
+- CLI skill generator plugin for generating Claude Code skills from any CLI tool ([#3](https://github.com/filipmares/agent-plugins/pull/3))
+
+## 2026-02-06
+
+### Added
+- Initial marketplace structure with validation scripts and documentation ([#1](https://github.com/filipmares/agent-plugins/pull/1))


### PR DESCRIPTION
## Problem

Running \/plugin list\ does not display a version for plugins installed from the marketplace (e.g. \consensus-planner@agent-plugins\), even though each plugin's own \plugin.json\ declares a version.

## Root Cause

The marketplace registry file (\.claude-plugin/marketplace.json\) did not include a \ersion\ field in its plugin entries. When the CLI installs a plugin from a marketplace, it reads the registry entry — not the plugin's own \plugin.json\ — so the version was never captured in the user's \config.json\.

## Fix

Added \ersion\ fields to all plugin entries in \marketplace.json\, matching each plugin's \plugin.json\:

| Plugin | Version |
|--------|---------|
| cli-skill-generator | 2.0.0 |
| plugin-analyzer | 1.0.0 |
| consensus-planner | 1.2.0 |

After this change, marketplace installs will correctly record the plugin version.