### PR TITLE
feat: multi-select model selection for consensus planner

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "consensus-planner",
       "source": "./plugins/consensus-planner",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "description": "Multi-model iterative consensus planning — spawns parallel agents to create, critique, and converge on implementation plans",
       "category": "development-tools",
       "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and plugin versioning follows [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [Unreleased]
 
+### Changed — consensus-planner v1.3.0
+- Multi-select model picker replaces iterative single-select loop in Step 2 ([#36](https://github.com/filipmares/agent-plugins/pull/36))
+
 ### Fixed
 - Add `version` field to all plugin entries in `marketplace.json` so marketplace installs correctly record plugin versions ([#35](https://github.com/filipmares/agent-plugins/pull/35))
 

--- a/plugins/consensus-planner/.claude-plugin/plugin.json
+++ b/plugins/consensus-planner/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "consensus-planner",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Multi-model iterative consensus planning — spawns parallel agents to create, critique, and converge on implementation plans",
   "author": { "name": "filipmares" },
   "homepage": "https://github.com/filipmares/agent-plugins",

--- a/plugins/consensus-planner/CHANGELOG.md
+++ b/plugins/consensus-planner/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.0
+
+### Multi-select model selection
+
+**Changes:**
+
+- **Multi-select model picker** — Step 2 now uses `ask_user` with `multiSelect: true` to let users pick all models in a single prompt, replacing the iterative single-select loop that required multiple round-trips
+
 ## 1.2.0
 
 ### Prompt quality, convergence, and reliability improvements
@@ -9,7 +17,7 @@
 - **Context exclusion patterns** — Step 1d now excludes `node_modules`, `dist`, `build`, `.next`, `vendor`, `__pycache__`, and other non-source directories/files from the glob, preventing wasted context slots
 - **Fixed-format output fields** — Planning prompt now requires `**Complexity: S | M | L**` and `**Files changed: <N>**` for reliable summary extraction and convergence checks
 - **Explicit Assumptions section** — Planning prompt requires a dedicated Assumptions subsection, surfacing implicit assumptions that cause plan divergence
-- **Multi-step model selection** — Step 2 uses an iterative `ask_user` loop to work within the single-select constraint, fixing a functional limitation
+- **Multi-step model selection** — Step 2 uses an iterative `ask_user` loop to work within the single-select constraint, fixing a functional limitation (superseded by multi-select in 1.3.0)
 - **Agent failure retry** — Steps 3 and 4 now retry failed agents once before falling back, improving resilience against transient API failures
 - **Output structure validation** — Step 3 validates that all 7 required sections are present in agent output, with a single retry for missing sections
 - **Disagreement ledger** — Feedback prompt now includes structured "Disagreements Resolved" and "Remaining Disagreements" sections, replacing vague convergence heuristics with agent-reported data

--- a/plugins/consensus-planner/skills/plan/SKILL.md
+++ b/plugins/consensus-planner/skills/plan/SKILL.md
@@ -100,13 +100,9 @@ If the project has more than 200 files, tell the user which files you selected a
 
 **Model selection:**
 
-Since `ask_user` is single-select, use an iterative loop to collect 1–5 models:
+Use `ask_user` with `multiSelect: true` to let the user pick 1–5 models in a single prompt. Present all `AVAILABLE_MODELS` as choices.
 
-1. Present all `AVAILABLE_MODELS` as choices → user picks first model
-2. Show remaining models plus a "Done selecting" option → user picks another or finishes
-3. Repeat until the user selects "Done" or 5 models are reached
-
-At each step, show which models are already selected. Recommend 2 models as a good default for cost/diversity balance:
+Recommend 2 models as a good default for cost/diversity balance:
 - For **Copilot CLI**, recommend picking models from different vendors (e.g., one Claude + one GPT + one Gemini)
 - For **Claude Code**, recommend picking models from different tiers (e.g., Opus + Sonnet)
 


### PR DESCRIPTION
## Summary

- Replace the iterative single-select model picker in the consensus planner skill with a single `multiSelect: true` `ask_user` prompt
- Users can now select 1–5 models in one step instead of cycling through multiple prompts
- Bump consensus-planner version to 1.3.0

## Changes

- **`plugins/consensus-planner/skills/plan/SKILL.md`** — Simplified Step 2 model selection from an iterative loop to a single multi-select prompt
- **`plugins/consensus-planner/.claude-plugin/plugin.json`** — Version bump to 1.3.0
- **`plugins/consensus-planner/CHANGELOG.md`** — Added 1.3.0 changelog entry
- **`.claude-plugin/marketplace.json`** — Updated marketplace version to 1.3.0

## Test plan

- [ ] Invoke `/consensus-planner:plan` and verify model selection presents a multi-select picker
- [ ] Confirm selecting multiple models works in a single prompt
- [ ] Confirm selecting a single model still triggers the single-model flow warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)